### PR TITLE
fix: checks response and converts to dict if needed

### DIFF
--- a/deepgram_captions/converters.py
+++ b/deepgram_captions/converters.py
@@ -1,9 +1,13 @@
+import json
 from .helpers import chunk_array, replace_text_with_word
 
 
 class DeepgramConverter:
     def __init__(self, dg_response):
-        self.response = dg_response
+        if not isinstance(dg_response, dict):
+            self.response = json.loads(dg_response.to_json())
+        else:
+            self.response = dg_response
 
     def get_lines(self, line_length):
         results = self.response["results"]


### PR DESCRIPTION
I have added logic to check the type of the data that is sent in to the converter. If it isn't a dict, the data will be converted to a dict since the converter expects it to be a dict type:

```py
if not isinstance(dg_response, dict):
            self.response = json.loads(dg_response.to_json())
        else:
            self.response = dg_response
```